### PR TITLE
Språk: Forenkle anmodning om regulære spilleavbrytelser

### DIFF
--- a/para14/index.md
+++ b/para14/index.md
@@ -20,7 +20,7 @@ parent: Kapittel 4 - Spillehandlinger
 ### 14.1.1
 {: #r14-1-1}
 Blokkering er handlingen til spillere nær nettet for å stanse ballen som kommer fra 
-motstanderne ved å rekke armene høyere enn nettets overkant, uavhengig av i hvilken 
+motstanderne ved å rekke høyere enn nettets overkant, uavhengig av i hvilken 
 høyde ballen treffer. Bare frontspillere kan fullføre en blokk, men i det øyeblikket 
 ballen berøres må en del av kroppen være over toppen av nettet.
 ([7.4.1.1](../para7/#r7-4-1-1))

--- a/para14/index.md
+++ b/para14/index.md
@@ -19,9 +19,9 @@ parent: Kapittel 4 - Spillehandlinger
 
 ### 14.1.1
 {: #r14-1-1}
-Blokkering er handlingen til spillere nær nettet for å stanse ballen som kommer fra 
-motstanderne ved å rekke høyere enn nettets overkant, uavhengig av i hvilken 
-høyde ballen treffer. Bare frontspillere kan fullføre en blokk, men i det øyeblikket 
+Blokkering er handlingen utført av spillere nær nettet for å stanse ballen som kommer fra 
+motstanderne ved å strekke seg høyere enn nettets overkant, uavhengig av i hvilken 
+høyde ballkontakten skjer. Bare frontspillere kan fullføre en blokk, men i det øyeblikket 
 ballen berøres må en del av kroppen være over toppen av nettet.
 ([7.4.1.1](../para7/#r7-4-1-1))
 

--- a/para15/index.md
+++ b/para15/index.md
@@ -56,7 +56,7 @@ avbruddet, før neste ballveksling er over.
 
 ### 15.3.1
 {: #r15-3-1}
-Treneren kan anmode om regulære spilleavbrytelser. Om treneren er fraværende kan regulære spilleavbrytelser anmodes av assistenttreneren eller av kampkapteinen, og bare av disse.
+Treneren kan be om regulære spilleavbrytelser. Om treneren er fraværende kan assistenttreneren eller kampkapteinen be om regulære spilleavbrytelser. Ingen andre kan be om regulære spilleavbrytelser.
 ([5.1.2](../para5/#r5-1-2), [5.2](../para5/#r5-2), [15](#r15))
 
 ### 15.3.2

--- a/para15/index.md
+++ b/para15/index.md
@@ -56,8 +56,7 @@ avbruddet, før neste ballveksling er over.
 
 ### 15.3.1
 {: #r15-3-1}
-Treneren kan anmode om regulære spilleravbrytelser, eller av kampkapteinen dersom 
-treneren eller assistenttrener ikke er tilgjengelig, og bare av disse.
+Treneren kan anmode om regulære spilleavbrytelser. Om treneren er fraværende kan regulære spilleavbrytelser anmodes av assistenttreneren eller av kampkapteinen, og bare av disse.
 ([5.1.2](../para5/#r5-1-2), [5.2](../para5/#r5-2), [15](#r15))
 
 ### 15.3.2


### PR DESCRIPTION
Dette dukket opp under arbeidet vi gjør i utvalget for Dommer 1-kurset. Dette punktet fører til en del forvirring. Vi sjekket med Jens Olav og Thomas, og fikk bekreftet at det korrekte er at assistenttrener og kampkaptein kun kan anmode om time-out i fravær av hovedtrener. Synes ikke den engelske formuleringen heller flyter lett, men tror dette blir en liten forbedring. 

Den engelske er: 

> Regular game interruptions may be requested by the coach, or in the 
> absence of the coach, by the assistant coach or by the game captain, 
> and only by them.