### PR TITLE
Feilretting: Sanksjoner for forsinkelse

### DIFF
--- a/para14/index.md
+++ b/para14/index.md
@@ -20,7 +20,7 @@ parent: Kapittel 4 - Spillehandlinger
 ### 14.1.1
 {: #r14-1-1}
 Blokkering er handlingen til spillere nær nettet for å stanse ballen som kommer fra 
-motstanderne ved å rekke armene høyere enn nettets overkant, uavhengig av i hvilken 
+motstanderne ved å rekke høyere enn nettets overkant, uavhengig av i hvilken 
 høyde ballen treffer. Bare frontspillere kan fullføre en blokk, men i det øyeblikket 
 ballen berøres må en del av kroppen være over toppen av nettet.
 ([7.4.1.1](../para7/#r7-4-1-1))

--- a/para14/index.md
+++ b/para14/index.md
@@ -19,9 +19,9 @@ parent: Kapittel 4 - Spillehandlinger
 
 ### 14.1.1
 {: #r14-1-1}
-Blokkering er handlingen til spillere nær nettet for å stanse ballen som kommer fra 
-motstanderne ved å rekke høyere enn nettets overkant, uavhengig av i hvilken 
-høyde ballen treffer. Bare frontspillere kan fullføre en blokk, men i det øyeblikket 
+Blokkering er handlingen utført av spillere nær nettet for å stanse ballen som kommer fra 
+motstanderne ved å strekke seg høyere enn nettets overkant, uavhengig av i hvilken 
+høyde ballkontakten skjer. Bare frontspillere kan fullføre en blokk, men i det øyeblikket 
 ballen berøres må en del av kroppen være over toppen av nettet.
 ([7.4.1.1](../para7/#r7-4-1-1))
 

--- a/para16/index.md
+++ b/para16/index.md
@@ -50,11 +50,11 @@ og omfatter blant annet:
 ### 16.2.1
 {: #r16-2-1}
 «Tilsnakk for forsinkelse» (delay warning) eller «advarsel for forsinkelse» (delay 
-penalty) er lagssanksjoner
+penalty) er lagssanksjoner.
 
 #### 16.2.1.1
 {: #r16-2-1-1}
-Sanksjon for forsinkelse gjelder for hele kampen.
+Sanksjoner for forsinkelse gjelder for hele kampen.
 ([6.3](../para6/#r6-3))
 
 #### 16.2.1.2
@@ -64,7 +64,7 @@ Alle sanksjoner for forsinkelser skrives inn i kampskjemaet.
 
 ### 16.2.2
 {: #r16-2-2}
-Første forsinkelse av et lag i et sett sanksjoneres med «tilsnakk for forsinkelse». 
+Første forsinkelse av et lag i en kamp sanksjoneres med «tilsnakk for forsinkelse». 
 ([4.1.1](../para4/#r4-1-1), fig. 11 (25))
 
 ### 16.2.3


### PR DESCRIPTION
To språklige korrigeringer (glemt punktum og flertallsform)

Endret feil i oversettelse. Første forsinkelse i en **kamp** gir gult kort, ikke i et _sett._