### PR TITLE
Regel: Korrigere kryssreferanser til ikke-eksisterende regelpunkter

### DIFF
--- a/para14/index.md
+++ b/para14/index.md
@@ -70,7 +70,6 @@ spilleren som berørte ballen i blokken.
 ## 14.5 Blokkering av serven
 {: #r14-5}
 Det er forbudt å blokkere en motspillers serve.
-([14.2.4](#r14-2-4))
 
 ## 14.6 Feil i blokkering
 {: #r14-6}

--- a/para15/index.md
+++ b/para15/index.md
@@ -243,8 +243,8 @@ Den første ukorrekte anmodningen som ikke influerer på eller forsinker spillet
 avvises, men må noteres i kampskjemaet uten andre konsekvenser.
 ([16.1](../para16/#r16-1), [27.2.2.6](../para27/#r27-2-2-6))
 
-#### 15.11.2.1
-{: #r15-11-2-1}
+### 15.11.3
+{: #r15-11-3}
 En hvilken som helst gjentatt ukorrekt anmodning i kampen gjelder som forsinkelse av 
 spillet.
 ([16.1.4](../para16/#r16-1-4)) 

--- a/para16/index.md
+++ b/para16/index.md
@@ -38,7 +38,7 @@ og omfatter blant annet:
 ### 16.1.4
 {: #r16-1-4}
 å gjenta ukorrekt anmodning; 
-([15.11.3](../para15/#r15-11-3))
+([15.11.2.1](../para15/#r15-11-2-1))
 
 ### 16.1.5
 {: #r16-1-5}

--- a/para16/index.md
+++ b/para16/index.md
@@ -38,7 +38,7 @@ og omfatter blant annet:
 ### 16.1.4
 {: #r16-1-4}
 å gjenta ukorrekt anmodning; 
-([15.11.2.1](../para15/#r15-11-2-1))
+([15.11.3](../para15/#r15-11-3))
 
 ### 16.1.5
 {: #r16-1-5}

--- a/para8/index.md
+++ b/para8/index.md
@@ -67,7 +67,7 @@ tilfellet Regel 10.1.2.
 ### 8.4.5
 {: #r8-4-5}
 den passerer fullstendig vertikalplanet under nettet.
-([23.3.23](../para23/#r23-3-23), fig. 5, fig. 11 (22)).
+([23.3.2.3](../para23/#r23-3-2-3), fig. 5, fig. 11 (22)).
 
 
 ## Fotnoter


### PR DESCRIPTION
## Fiks: Korrigere kryssreferanser til ikke-eksisterende regler

### Beskrivelse
 Denne PR-en fikser kryssreferanser som pekte til regler som ikke eksisterte, samt legger til en
 manglende regel.

_Igjen er endringane identifisert ved hjelp av ei agent. Har validert at dei to første er feil i den i norske oversettinga - og er riktig referert på engelsk.
Den siste ser det ut til at den norske regelen har fått feil nummer i oversettinga._

 ### Endringer

 | Fil | Problem | Løsning |
 |-----|---------|---------|
 | `para14/index.md` (14.5) | Refererte til 14.2.4 som ikke eksisterer | Fjernet referansen (regelen er selvforklarende) |
 | `para8/index.md` (8.4.5) | Refererte til 23.3.23 (skrivefeil) | Endret til 23.3.2.3 (regel om ball under nettet) |
 | `para15/index.md` | Regel 15.11.3 manglet | Oppgraderte 15.11.2.1 til 15.11.3 (egen regel) |

 ### Kontekst
 Feilene ble oppdaget ved systematisk og agentisk gjennomgang av regelverket for innholdsmessige
 inkonsistenser.